### PR TITLE
Fix `SQLite` compilation usage of flag `SQLITE_OMIT_LOAD_EXTENSION`

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,7 @@ Versioning follows the following pattern of `SQLDelight` - `SQLite3MultipleCiphe
 `SQLITE_MAX_FUNCTION_ARG=127`  
 `SQLITE_MAX_ATTACHED=125`  
 `SQLITE_MAX_PAGE_COUNT=4294967294`  
-`SQLITE_DQS=0`  
-`OMIT_LOAD_EXTENSION`  
+`SQLITE_DQS=0`   
 `CODEC_TYPE=CODEC_TYPE_CHACHA20`  
 `SQLITE_ENABLE_EXTFUNC=1`  
 `SQLITE_ENABLE_REGEXP=1`  
@@ -300,6 +299,7 @@ Versioning follows the following pattern of `SQLDelight` - `SQLite3MultipleCiphe
 **Native:**
 
 `SQLITE_THREADSAFE=2`  
+`SQLITE_OMIT_LOAD_EXTENSION`
 
 <details>
     <summary>Reason</summary>
@@ -312,7 +312,13 @@ SQLDelight's NativeSqliteDriver utilizes thread pools
 and nerfs any benefit that Serialized would offer, so.
 
 This *might* change in the future if migrating away from
-SQLDelight's NativeSqliteDriver and SQLiter
+SQLDelight's NativeSqliteDriver and SQLiter.
+
+Omission of the load extension code is only able to be
+set for Native, as Jvm requires the code to remain in
+order to link with the JNI interface. Extension loading
+is disabled by default for Jvm, but the C code must stay
+in order to mitigate modifying the Java codebase.
 ```
 
 </details>
@@ -320,7 +326,7 @@ SQLDelight's NativeSqliteDriver and SQLiter
 **Darwin:**
 
 `SQLITE_ENABLE_API_ARMOR`  
-`OMIT_AUTORESET`  
+`SQLITE_OMIT_AUTORESET`  
 
 <details>
     <summary>Reason</summary>

--- a/external/patches/0010-Configure-build-to-use-SQLite3MultipleCiphers.patch
+++ b/external/patches/0010-Configure-build-to-use-SQLite3MultipleCiphers.patch
@@ -1,17 +1,17 @@
-From bbc25fa3fd5a4ecaf908f1272ed99459b2c36667 Mon Sep 17 00:00:00 2001
+From a16bb65834f37d3a5916fabab8b8449e678e99f4 Mon Sep 17 00:00:00 2001
 From: Matthew Nelson <developer@matthewnelson.io>
 Date: Sat, 30 Sep 2023 15:05:38 -0400
 Subject: [PATCH 10/11] Configure build to use SQLite3MultipleCiphers
 
 ---
- Makefile                                 | 23 +++++++++---------
+ Makefile                                 | 22 ++++++++---------
  Makefile.common                          | 30 ++++++++++++------------
  VERSION                                  |  1 +
  src/main/java/org/sqlite/core/NativeDB.c |  2 +-
- 4 files changed, 29 insertions(+), 27 deletions(-)
+ 4 files changed, 28 insertions(+), 27 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 840ad53..bdb31d7 100644
+index 840ad53..5bf51b4 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -19,7 +19,7 @@ SQLITE_OBJ?=$(SQLITE_OUT)/sqlite3.o
@@ -46,11 +46,10 @@ index 840ad53..bdb31d7 100644
  	    -DSQLITE_MAX_LENGTH=2147483647 \
  	    -DSQLITE_MAX_COLUMN=32767 \
  	    -DSQLITE_MAX_SQL_LENGTH=1073741824 \
-@@ -90,10 +85,16 @@ $(SQLITE_OUT)/sqlite3.o : $(SQLITE_UNPACKED)
+@@ -90,10 +85,15 @@ $(SQLITE_OUT)/sqlite3.o : $(SQLITE_UNPACKED)
  	    -DSQLITE_MAX_ATTACHED=125 \
  	    -DSQLITE_MAX_PAGE_COUNT=4294967294 \
  	    -DSQLITE_DQS=0 \
-+	    -DOMIT_LOAD_EXTENSION \
 +	    -DCODEC_TYPE=CODEC_TYPE_CHACHA20 \
 +	    -DSQLITE_ENABLE_EXTFUNC=1 \
 +	    -DSQLITE_ENABLE_REGEXP=1 \
@@ -65,7 +64,7 @@ index 840ad53..bdb31d7 100644
  
  $(SQLITE_OUT)/$(LIBNAME): $(SQLITE_HEADER) $(SQLITE_OBJ) $(SRC)/org/sqlite/core/NativeDB.c $(TARGET)/common-lib/NativeDB.h
  	@mkdir -p $(@D)
-@@ -109,7 +110,7 @@ NATIVE_TARGET_DIR:=$(TARGET)/classes/org/sqlite/native/$(OS_NAME)/$(OS_ARCH)
+@@ -109,7 +109,7 @@ NATIVE_TARGET_DIR:=$(TARGET)/classes/org/sqlite/native/$(OS_NAME)/$(OS_ARCH)
  NATIVE_DLL:=$(NATIVE_DIR)/$(LIBNAME)
  
  # For cross-compilation, install docker. See also https://github.com/dockcross/dockcross

--- a/external/patches/0011-Replace-getentropy-with-SecRandomCopyBytes.patch
+++ b/external/patches/0011-Replace-getentropy-with-SecRandomCopyBytes.patch
@@ -1,6 +1,6 @@
-From 7000cec176ebb84b79e33f0cc7235a278f222e19 Mon Sep 17 00:00:00 2001
+From 35e40ea380592f95e7cd230b65bab20c5a9cd685 Mon Sep 17 00:00:00 2001
 From: Matthew Nelson <developer@matthewnelson.io>
-Date: Wed, 4 Oct 2023 07:59:56 -0400
+Date: Thu, 5 Oct 2023 15:28:51 -0400
 Subject: [PATCH 11/11] Replace getentropy with SecRandomCopyBytes
 
 ---
@@ -11,7 +11,7 @@ Subject: [PATCH 11/11] Replace getentropy with SecRandomCopyBytes
  create mode 100755 sec_random_copy_bytes.sh
 
 diff --git a/Makefile b/Makefile
-index bdb31d7..e11f983 100644
+index 5bf51b4..e126f9d 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -39,6 +39,7 @@ $(SQLITE_UNPACKED): $(SQLITE_ARCHIVE)

--- a/library/driver/build.gradle.kts
+++ b/library/driver/build.gradle.kts
@@ -276,7 +276,7 @@ fun CompileToBitcodeExtension.createSqlite3mc() {
             // Darwin devices. macOS 10.11.6+, iOS 9.3.5+
             listOf(
                 "-DSQLITE_ENABLE_API_ARMOR",
-                "-DOMIT_AUTORESET",
+                "-DSQLITE_OMIT_AUTORESET",
             ).let { compilerArgs.addAll(it) }
         }
 
@@ -290,6 +290,11 @@ fun CompileToBitcodeExtension.createSqlite3mc() {
             // This *might* change in the future if migrating away from
             // SQLDelight's NativeSqliteDriver and SQLiter
             "-DSQLITE_THREADSAFE=2",
+
+            // This removes extension loading entirely. On Jvm, this flag
+            // is needed at compile time because of the JNI interface, but
+            // for native it is completely disabled.
+            "-DSQLITE_OMIT_LOAD_EXTENSION",
 
             // Remaining flags are what JVM is compiled with
             "-DSQLITE_HAVE_ISNAN=1",
@@ -314,7 +319,6 @@ fun CompileToBitcodeExtension.createSqlite3mc() {
             "-DSQLITE_MAX_ATTACHED=125",
             "-DSQLITE_MAX_PAGE_COUNT=4294967294",
             "-DSQLITE_DQS=0",
-            "-DOMIT_LOAD_EXTENSION",
             "-DCODEC_TYPE=CODEC_TYPE_CHACHA20",
             "-DSQLITE_ENABLE_EXTFUNC=1",
             "-DSQLITE_ENABLE_REGEXP=1",


### PR DESCRIPTION
Closes #60 

Note that `sqlite-jdbc` did not need to be re-compiled, as the original flag being used was incorrect and being ignored anyways. I did recompile again **without** the flag, and the binaries that were output matched, showing no git changes (except for Windows, but that is just a thing with windows binaries; they never match).