### PR TITLE
Use `implementation` instead of `api` for plugin dependency

### DIFF
--- a/library/gradle-plugin/build.gradle.kts
+++ b/library/gradle-plugin/build.gradle.kts
@@ -87,10 +87,12 @@ tasks.named<Test>("test") {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(17))
     })
-    environment(
-        Pair("ORG_GRADLE_PROJECT_sqlitemcVersion", project.version),
-        Pair("ORG_GRADLE_PROJECT_KMP_TARGETS", findProperty("KMP_TARGETS")),
-    )
+
+    val env = mutableMapOf(Pair("ORG_GRADLE_PROJECT_sqlitemcVersion", project.version))
+    findProperty("KMP_TARGETS")?.let { targets ->
+        env["ORG_GRADLE_PROJECT_KMP_TARGETS"] = targets
+    }
+    environment(env)
 }
 
 configureTestOutput()

--- a/library/gradle-plugin/src/main/kotlin/io/toxicity/sqlite/mc/gradle/SQLiteMCPlugin.kt
+++ b/library/gradle-plugin/src/main/kotlin/io/toxicity/sqlite/mc/gradle/SQLiteMCPlugin.kt
@@ -52,7 +52,7 @@ abstract class SQLiteMCPlugin internal constructor(): Plugin<Project> {
             .getByName(
                 sourceSets
                     .getByName(sourceSetMainName)
-                    .apiConfigurationName
+                    .implementationConfigurationName
             )
             .dependencies
             .add(dependencies.create("io.toxicity.sqlite-mc:driver:$VERSION"))


### PR DESCRIPTION
Closes #62