### PR TITLE
Use `-h sha256` when codesigning windows .ddl files

### DIFF
--- a/external/task.sh
+++ b/external/task.sh
@@ -156,6 +156,7 @@ function sign:mingw { ## Sign Windows libs. (see windows.pkcs11.sample)
       -key "$pkcs11_url" \
       -certs "$gen_cert_path" \
       -ts "$gen_ts" \
+      -h "sha256" \
       -in "$dir_arch/sqlitejdbc.dll" \
       -out "$DIR_SIGNED/Windows/$arch_name/sqlitejdbc.dll"
   done


### PR DESCRIPTION
Closes #116 