### PR TITLE
Remove flag `embed-bitcode` from native compilations

### DIFF
--- a/library/driver/build.gradle.kts
+++ b/library/driver/build.gradle.kts
@@ -144,7 +144,6 @@ kmpConfiguration {
                     // -O3 set automatically for C language
 
                     listOf(
-                        "-fembed-bitcode",
                         "-fvisibility=hidden",
                     ).let { compilerArgs.addAll(it) }
 


### PR DESCRIPTION
Closes #146 