### PR TITLE
Ensure arm64/32 have cpu crypto instructions specified when compiling

### DIFF
--- a/library/driver/build.gradle.kts
+++ b/library/driver/build.gradle.kts
@@ -161,12 +161,17 @@ kmpConfiguration {
 
                     // Architecture specific flags
                     when (kt.architecture) {
+                        ARM64 -> listOf(
+                            "-march=armv8-a+crypto",
+                        )
+                        ARM32 -> listOf(
+                            "-mfpu=neon",
+                        )
                         X64, X86 -> listOf(
                             "-msse4.2",
                             "-maes",
                         )
-                        else -> null
-                    }?.let { compilerArgs.addAll(it) }
+                    }.let { compilerArgs.addAll(it) }
 
                     // Warning/Error suppression flags
                     buildList {


### PR DESCRIPTION
This PR fixes a compilation error for linux `aarch64` when compiling from `macOS` host.